### PR TITLE
Update eslintrc rules syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ module.exports = {
     "eslint-plugin-parentheses-around-await"
   ],
   "rules": {
-    "parentheses-around-await": 1 // 2 - error, 1 - warn, 0 - off.
+    "parentheses-around-await/parentheses-around-await": 1 // 2 - error, 1 - warn, 0 - off.
   }
 };
 


### PR DESCRIPTION
Hey @yakovenkodenis, thanks for the plugin! I just experienced a bug
that it would have caught, so I'm adding it to my project now.

I noticed that I had to tweak the eslintrc rules syntax a bit to avoid
an error where it couldn't find the definition of the rule, so I wanted
to update the readme accordingly.

See https://eslint.org/docs/developer-guide/working-with-plugins:

> To use the rule in ESLint, you would use the unprefixed plugin name,
followed by a slash, followed by the rule name. So if this plugin
were named `eslint-plugin-myplugin`, then in your configuration you'd
refer to the rule by the name `myplugin/dollar-sign`. Example:
`"rules": {"myplugin/dollar-sign": 2}`.