### PR TITLE
Fix tests, typo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-import paranthesesAroundAwait from './rules/parentheses-around-await';
+import parenthesesAroundAwait from './rules/parentheses-around-await';
 
 export = {
   rules: {
-    'parentheses-around-await': paranthesesAroundAwait,
+    'parentheses-around-await': parenthesesAroundAwait,
   },
 };

--- a/src/rules/parentheses-around-await.test.ts
+++ b/src/rules/parentheses-around-await.test.ts
@@ -26,9 +26,9 @@ tester.run('parentheses-around-await', rule, {
       errors: [
         {
           message: `If you want to access properties on an awaited value,
-      you should wrap the value with parantheses. If not, 
-      you may get undefined which will lead to bugs.
-      `,
+                      you should wrap the value with parentheses. If not, 
+                      you may get undefined which will lead to bugs.
+                      `,
         },
       ],
     },

--- a/src/rules/parentheses-around-await.ts
+++ b/src/rules/parentheses-around-await.ts
@@ -8,7 +8,7 @@ const rule: Rule.RuleModule = {
         if (node.type) {
           context.report({
             message: `If you want to access properties on an awaited value,
-                      you should wrap the value with parantheses. If not, 
+                      you should wrap the value with parentheses. If not, 
                       you may get undefined which will lead to bugs.
                       `,
             node,


### PR DESCRIPTION
`yarn test` was failing like this:

        Expected value to strictly be equal to:
          "If you want to access properties on an awaited value,
              you should wrap the value with parantheses. If not,·
              you may get undefined which will lead to bugs.
              "
        Received:
          "If you want to access properties on an awaited value,
                              you should wrap the value with parantheses. If not,·
                              you may get undefined which will lead to bugs.

So I fixed the indentation, as well as a typo I noticed along the way ("parantheses")